### PR TITLE
Correct the spelling of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 One line lazy property definition, with auto triggering, custom selectors
 
-ARC only, XCode 4.4 minimum (For auto synthesized properties)
+ARC only, Xcode 4.4 minimum (For auto synthesized properties)
 
 ##Description
 Dealing with lazy properties can be cumbersome sometimes, copy/pasting same code again and again.<br/>


### PR DESCRIPTION
This pull request corrects the spelling of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
